### PR TITLE
fix: make esm import to be the default

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
This project is ESM by default (`"type": "module"`) since #76 
So tsup generate `.cjs` for CommonJS & `.js` for ESM

`@topcli/spinner#2.1.0` is broken due to theses missing changes