### PR TITLE
fix: fixing CJK characters misaligning

### DIFF
--- a/src/Spinner.class.ts
+++ b/src/Spinner.class.ts
@@ -153,7 +153,7 @@ export class Spinner extends EventEmitter {
     const line = this.#lineToRender(spinnerSymbol);
     readline.clearLine(this.stream, 0);
     this.stream.write(line);
-    readline.moveCursor(this.stream, -line.length, moveCursorPos);
+    readline.moveCursor(this.stream, -(wcwidth(line)), moveCursorPos);
   }
 
   start(text?: string, options: IStartOptions = {}) {


### PR DESCRIPTION
resolves #101,  now CJK characters printed as intended.
tested on my local environment.

thanks for your great work again!



https://github.com/TopCli/Spinner/assets/7118300/2a4079a9-bced-4402-9815-40fc31af9d35

